### PR TITLE
Replace all instances of RJArthern with WAVI-ice-sheet-model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WAVIhpc
 
-A configuration and helper repository to assist with running [WAVI](https://github.com/RJArthern/WAVI.jl) ensembles locally or on HPCs using [model-ensembler](https://github.com/environmental-forecasting/model-ensembler).
+A configuration and helper repository to assist with running [WAVI](https://github.com/WAVI-ice-sheet-model/WAVI.jl) ensembles locally or on HPCs using [model-ensembler](https://github.com/environmental-forecasting/model-ensembler).
 
 ## Supported Platforms
 Currently WAVIhpc supports execution in single mode and ensemble mode on the following platforms:

--- a/docs/functionality.md
+++ b/docs/functionality.md
@@ -1,6 +1,6 @@
 # Functionality
 ## `wavi_install`
-Installs [WAVI](https://github.com/RJArthern/WAVI.jl) into a Julia Pkg Environment.
+Installs [WAVI](https://github.com/WAVI-ice-sheet-model/WAVI.jl) into a Julia Pkg Environment.
 
 ```
 wavi_install

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 
 It is recommended you have some familiarity of how to _use_:
 
-* [WAVI](https://rjarthern.github.io/WAVI.jl/).
+* [WAVI](https://WAVI-ice-sheet-model.github.io/WAVI.jl/).
 * [model-ensembler](https://model-ensembler.readthedocs.io/en/latest).
 * Running SLURM jobs on your chosen platform ([BAS HPC (internal)](https://gitlab.data.bas.ac.uk/kinton/hpc-training/-/blob/main/7%20-%20Slurm%20Scheduler.ipynb), [JASMIN LOTUS](https://help.jasmin.ac.uk/docs/batch-computing/lotus-overview/), [ARCHER2](https://docs.archer2.ac.uk/user-guide/scheduler/)).
 
@@ -143,7 +143,7 @@ To install WAVI:
 wavi_install
 ```
 
-This will install [WAVI](https://github.com/RJArthern/WAVI.jl).
+This will install [WAVI](https://github.com/WAVI-ice-sheet-model/WAVI.jl).
 
 !!! note "Pkg environments"
 

--- a/docs/templates_cases.md
+++ b/docs/templates_cases.md
@@ -33,7 +33,7 @@ All other cases also follow this structure. The directories contain the followin
 
 * `/code`: Empty in templates, but could contain additional (e.g. Julia) code required to run your ensemble.
 * `/ensemble`: Contains a [model-ensembler configuration](https://model-ensembler.readthedocs.io/en/latest/user/configuration/) file, `template.yaml`.
-* `/input`: Contains input files, in this case `driver.jl`/`driver.jl.j2`, files which instantiate, configure and run the WAVI simulation. Also see [WAVI API Overview](https://rjarthern.github.io/WAVI.jl/data_structure/overview/).
+* `/input`: Contains input files, in this case `driver.jl`/`driver.jl.j2`, files which instantiate, configure and run the WAVI simulation. Also see [WAVI API Overview](https://WAVI-ice-sheet-model.github.io/WAVI.jl/data_structure/overview/).
 * `/run`: An empty folder, which will contain output files for each run.
 * `/scripts`: Contains scripts `prep_run`, `run_driver.jl`, `run_ensemble_member`/`run_ensemble_member.j2`, whose execution are configured by `/ensemble/template.yaml`
 
@@ -58,7 +58,7 @@ See JASMIN's [batch computing documentation](https://help.jasmin.ac.uk/docs/batc
 ### ATTR_666
 
 ### MISMIP_666
-This case is intended to simulate the [Marine Ice Sheet Model Intercomparison](https://tc.copernicus.org/articles/14/2283/2020/), which you can also follow in the [WAVI documentation](https://rjarthern.github.io/WAVI.jl/examples/mismip_plus).
+This case is intended to simulate the [Marine Ice Sheet Model Intercomparison](https://tc.copernicus.org/articles/14/2283/2020/), which you can also follow in the [WAVI documentation](https://WAVI-ice-sheet-model.github.io/WAVI.jl/examples/mismip_plus).
 
 Configured to run on ARCHER2, MISMIP_666 contains changes to `input/driver.jl`, as well as additional files under `/scripts`: `prep_run.sh`, `rsync_jld2.sh`, `rsync_mat.sh`, `rsync.sh`, `run_repeat.sh` and `sub_run.sh`.
 

--- a/scripts/julia_install_wavi.jl
+++ b/scripts/julia_install_wavi.jl
@@ -7,7 +7,7 @@ env_name = "WAVI_ENV" in keys(ENV) ? ENV["WAVI_ENV"] : "wavi_test"
 Pkg.activate(joinpath("envs", env_name))
 
 repo = "WAVI_REPO" in keys(ENV) ? ENV["WAVI_REPO"] :
-    "https://github.com/RJArthern/WAVI.jl.git"
+    "https://github.com/WAVI-ice-sheet-model/WAVI.jl.git"
 rev = "WAVI_REV" in keys(ENV) ? ENV["WAVI_REV"] : "main"
 
 dev_folder = nothing


### PR DESCRIPTION
As WAVI.jl has now moved to https://github.com/WAVI-ice-sheet-model/WAVI.jl, all installation scripts and documentation referencing the old location need to be replaced.