### PR TITLE
Enable extra parameters to be passed to `model_ensemble` when using `wavi_ensemble`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ WAVIhpc provides convenience function to help set up and run WAVI ensembles:
 
 * `wavi_install`: Installs WAVI into a Julia environment.
 * `wavi_create_case`: Creates a new ensembling case based on a provided template.
-* `wavi_ensemble`: Runs a WAVI ensemble.
+* `wavi_ensemble`: Runs a WAVI ensemble, with optional extra parameters passed to model_ensemble.
 * `wavi_execute`: Runs a single execution of WAVI (ie not an ensemble).
 
 ## Templates and Use Cases

--- a/docs/functionality.md
+++ b/docs/functionality.md
@@ -30,13 +30,18 @@ Sets up the Python environment, installs model-ensembler and calls `model_ensemb
 
 ```
 # Usage
-wavi_ensemble <ensemble-name> <case-template>
+wavi_ensemble <ensemble-name> <case-template> [additional_model_ensemble_args...]
 
-# Example
+# Examples
 wavi_ensemble test_ensemble anewcase
+wavi_ensemble my_ensemble template_bas --dry-run
+wavi_ensemble my_ensemble MISMIP_666 --pickup --skips 10
 ```
 
-Where the first argument is a name you want to give your ensemble, and the second argument is the cases folder you have configured it in.
+Where:
+- The first argument is a name you want to give your ensemble
+- The second argument is the cases folder you have configured (defaults to "template" if not specified)
+- Any additional arguments are passed directly to the underlying `model_ensemble` command. You can check `model_ensemble --help` for these arguments.
 
 ## `wavi_execute`
 Provides a single execution command for WAVI:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,14 @@ Finally, to run your ensemble:
 wavi_ensemble test_ensemble anewcase
 ```
 
+You can pass additional parameters to the underlying `model_ensemble` command by adding them after the case template:
+
+```bash
+wavi_ensemble my_ensemble MISMIP_666 --pickup --skips 10
+```
+
+The extra parameters are passed directly to `model_ensemble` at the end of the command, after the configuration file and target. Run `model_ensemble --help` to see all parameter options.
+
 ## Single execution
 You can also try running WAVI in single execution mode:
 

--- a/scripts/local/wavi_ensemble
+++ b/scripts/local/wavi_ensemble
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 1 ]; then
-  echo "Usage $0 <ensembleName> [ensembleTemplateCase]"
+  echo "Usage $0 <ensembleName> [caseDirectory] [additional_model_ensemble_args...]"
+  echo "Examples:"
+  echo "  $0 my_ensemble template_bas --dry-run -vv"
+  echo "  $0 my_ensemble MISMIP_666 --pickup --skips 10"
+  echo "  $0 my_ensemble template --dry-run"
   exit 1
 fi
 
@@ -27,6 +31,11 @@ CFG_DIR="`dirname $0`"
 ENSEMBLE_TARGET="slurm"
 ENSEMBLE_NAME="${1}"
 ENSEMBLE_TEMPLATE_CASE="${2:-template}"
+
+# All arguments after the first two are extra args for model_ensemble
+shift 2
+EXTRA_ARGS=("$@")
+
 ENSEMBLE_CONFIG="cases/${ENSEMBLE_TEMPLATE_CASE}/ensemble/${ENSEMBLE_NAME}.yaml"
 if [ "$ENSEMBLE_TYPE" == "local" ]; then
   ENSEMBLE_TARGET="dummy"
@@ -38,6 +47,8 @@ sed -r \
   cases/$ENSEMBLE_TEMPLATE_CASE/ensemble/template.yaml \
   >${ENSEMBLE_CONFIG}
 
-model_ensemble -ms 30 -ct 30 -st 20 -rt 120 -p -v ${ENSEMBLE_CONFIG} $ENSEMBLE_TARGET
+# Run model_ensemble with default parameters, config, target, and extra args at the end
+echo "Running: model_ensemble -ms 30 -ct 30 -st 20 -rt 120 -p -v ${ENSEMBLE_CONFIG} $ENSEMBLE_TARGET ${EXTRA_ARGS[*]}"
+model_ensemble -ms 30 -ct 30 -st 20 -rt 120 -p -v ${ENSEMBLE_CONFIG} $ENSEMBLE_TARGET "${EXTRA_ARGS[@]}"
 
 exit $?

--- a/scripts/local/wavi_ensemble
+++ b/scripts/local/wavi_ensemble
@@ -3,9 +3,8 @@
 if [ $# -lt 1 ]; then
   echo "Usage $0 <ensembleName> [caseDirectory] [additional_model_ensemble_args...]"
   echo "Examples:"
-  echo "  $0 my_ensemble template_bas --dry-run -vv"
+  echo "  $0 my_ensemble template_bas"
   echo "  $0 my_ensemble MISMIP_666 --pickup --skips 10"
-  echo "  $0 my_ensemble template --dry-run"
   exit 1
 fi
 


### PR DESCRIPTION
Closes #19, enables passing extra arguments to `model_ensemble` when calling it with `wavi_ensemble`.

For example:

```sh
wavi_ensemble my_ensemble MISMIP_666 --pickup --skips 10
```